### PR TITLE
Fix make commands in README, generate-tfvars.sh skip, curl step retry in validation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,14 +128,12 @@ If you need to override any of the defaults, simply replace the desired value(s)
 
 ### Provisioning the Kubernetes Engine Cluster
 
-Next, apply the terraform configuration with:
+Next, apply the terraform configuration and create the environment with:
 
 ```console
 # From within the project root, use make to apply the terraform
-make tf-apply
+make create
 ```
-
-When prompted if you want to deploy the plan, review the generated plan and enter `yes` to deploy the environment.
 
 ## Validation
 
@@ -340,7 +338,7 @@ And you'll see that the pods have an additional "updated=..." label.
 The test cluster can be completely torn down with the following command (type `yes` at the prompt to confirm)
 
 ```command
-make tf-destroy
+make teardown
 
 ...snip...
 module.network.google_compute_subnetwork.cluster-subnet: Destruction complete after 26s
@@ -360,7 +358,7 @@ The credentials that Terraform is using do not provide the necessary permissions
 
 ### Error during scp
 
-Occasionally, the gke-tutorial-bastion host will not be ready for the subsequent `scp` command, in this case there will be an error that looks like: ![terraform scp error](./img/bastion_scp_error.png) If this happens, simply re-run `make tf-apply`.
+Occasionally, the gke-tutorial-bastion host will not be ready for the subsequent `scp` command, in this case there will be an error that looks like: ![terraform scp error](./img/bastion_scp_error.png) If this happens, simply re-run `make create`.
 
 ### Invalid fingerprint error during Terraform operations
 

--- a/scripts/generate-tfvars.sh
+++ b/scripts/generate-tfvars.sh
@@ -93,9 +93,14 @@ TFVARS_FILE="$ROOT/terraform/terraform.tfvars"
 # We don't want to overwrite a pre-existing tfvars file
 if [[ -f "${TFVARS_FILE}" ]]
 then
-    echo "${TFVARS_FILE} already exists." 1>&2
-    echo "Please remove or rename before regenerating." 1>&2
-    exit 1;
+    echo "${TFVARS_FILE} already exists, and will not be overwritten." 1>&2
+    echo "Contents are:" 1>&2
+    echo "---" 1>&2
+    cat "${TFVARS_FILE}"
+    echo "---" 1>&2
+    echo "Sleeping 10s before proceeding.  Press Ctrl-c to abort and make any desired changes." 1>&2
+    sleep 10
+    echo "Proceeding with the above contents." 1>&2
 else
 # Write out all the values we gathered into a tfvars file so you don't
 # have to enter the values manually


### PR DESCRIPTION
Adjusting make commands to line up with the Makefile.

Running make setup-project generates the terraform/terraform.tfvars by running scripts/generate-tfvars.sh. When make create is called, it also calls scripts/generate-tfvars.sh. The existence of that file causes it to exit 1 and make create to fail. Removing the logic to exit 1 allows the make create to work again. Instead a note to the user and a sleep 10 allows them time to review and abort for some reason before the terraform apply is run.

Also, adding retry on the curl command for failed `make validate`.