### PR TITLE
Updated Readme, fixed terraform code for private cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,7 +356,8 @@ And you'll see that the pods have an additional "updated=..." label.
 
 ## Tear down
 
-The test cluster can be completely torn down with the following command (type `yes` at the prompt to confirm)
+
+Log out of the bastion host and run the following to destroy the environment (type `yes` at the prompt to confirm)
 
 ```command
 make teardown

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -104,8 +104,12 @@ resource "google_container_cluster" "primary" {
     cluster_secondary_range_name = "secondary-range"
   }
 
-  master_ipv4_cidr_block = "10.0.90.0/28"
-  private_cluster        = true
+  // In a private cluster, the master has two IP addresses, one public and one
+  // private. Nodes communicate to the master through this private IP address.
+  private_cluster_config {
+    enable_private_nodes   = true
+    master_ipv4_cidr_block = "10.0.90.0/28"
+  }
 
   // (Required for private cluster, optional otherwise) network (cidr) from which cluster is accessible
   master_authorized_networks_config {


### PR DESCRIPTION
Below changes made:

1. READme file: Added instructions for teardown command.
2. terraform/main.tf: Replaced deprecated field private_clusters to newer version i.e private_cluster_config block.