### PR TITLE
Updating image dependencies to fix broken build.

### DIFF
--- a/images/custom-nginx/Dockerfile
+++ b/images/custom-nginx/Dockerfile
@@ -11,17 +11,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-FROM nginx:alpine
+FROM nginx:1.17.9-alpine
 
 COPY ./nginx.conf /etc/nginx/nginx.conf
 COPY ./default.conf /etc/nginx/conf.d/default.conf
 
-RUN apk update && apk add shadow=4.5-r0 openrc=0.24.1-r4 nginx=1.12.2-r3 \
+RUN apk update && apk add shadow=4.6-r2 openrc=0.41.2-r1 nginx \
     --no-cache && \
     groupadd -g 1000 appuser && useradd -ru 1000 -g appuser appuser && \
-    chown -R appuser:appuser /var/lib/nginx/ && \
-    chown -R appuser:appuser /var/tmp/nginx/ && \
+    chown -R appuser:appuser /usr/lib/nginx/ && \
+    chown -R appuser:appuser /var/cache/nginx/ && \
+    chown -R appuser:appuser /etc/nginx/ && \
     touch /var/run/nginx.pid && \
-    chown appuser:appuser /var/run/nginx.pid
+    chown -R appuser:appuser /run
 
 USER appuser

--- a/images/custom-nginx/nginx.conf
+++ b/images/custom-nginx/nginx.conf
@@ -12,9 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The import part of this file is that we are running the worker processes as
-# appuser instead of nobody
-user appuser;
 worker_processes  1;
 
 error_log  /var/log/nginx/error.log warn;


### PR DESCRIPTION
- The user directive in nginx.conf was removed because it is redundant
in the latest nginx and causes a runtime warning.