### PR TITLE
migrate cluster nodes to containerd image

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -85,7 +85,7 @@ resource "google_container_cluster" "primary" {
     ]
 
     machine_type = var.node_machine_type
-    image_type   = "COS"
+    image_type   = "COS_CONTAINERD"
 
     // (Optional) The Kubernetes labels (key/value pairs) to be applied to each node.
     labels = {


### PR DESCRIPTION
The COS image is deprecated in GKE 1.24 as a result of the dockershim deprecation: https://kubernetes.io/blog/2022/01/07/kubernetes-is-moving-on-from-dockershim/