### PR TITLE
Update compute image version

### DIFF
--- a/terraform/modules/instance/main.tf
+++ b/terraform/modules/instance/main.tf
@@ -61,7 +61,7 @@ tags         = var.tags
 // Specify the Operating System Family and version.
 boot_disk {
 initialize_params {
-image = "debian-cloud/debian-9"
+image = "debian-cloud/debian-10"
 }
 }
 


### PR DESCRIPTION
debian-cloud/debian-9 removed out of images list (gcloud compute images list | grep debian-cloud)