### PR TITLE
fix debian-9 no longer available

### DIFF
--- a/terraform/modules/instance/main.tf
+++ b/terraform/modules/instance/main.tf
@@ -61,7 +61,7 @@ tags         = var.tags
 // Specify the Operating System Family and version.
 boot_disk {
 initialize_params {
-image = "debian-cloud/debian-9"
+image = "debian-cloud/debian-10"
 }
 }
 


### PR DESCRIPTION
With image list from "gcloud compute images list | grep debian", there is no debian-9 from GCP.

"make create" will cause
Error resolving image name 'debian-cloud/debian-9': Could not find image or family debian-cloud/debian-9

Just update debian version to fix it.