### PR TITLE
Remove tfvars file after successful terraform destroy

### DIFF
--- a/scripts/generate-tfvars.sh
+++ b/scripts/generate-tfvars.sh
@@ -17,7 +17,7 @@
 # "---------------------------------------------------------"
 # "-                                                       -"
 # "-  Helper script to generate terraform variables        -"
-# "-  file based on glcoud defaults.                       -"
+# "-  file based on gcloud defaults.                       -"
 # "-                                                       -"
 # "---------------------------------------------------------"
 
@@ -33,7 +33,7 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 command -v git >/dev/null 2>&1 || { \
  echo >&2 "I require git but it's not installed.  Aborting."; exit 1; }
 
-# glcoud is required for this tutorial
+# gcloud is required for this tutorial
 command -v gcloud >/dev/null 2>&1 || { \
  echo >&2 "I require gcloud but it's not installed.  Aborting."; exit 1; }
 

--- a/scripts/teardown.sh
+++ b/scripts/teardown.sh
@@ -30,5 +30,5 @@ ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
 source "$ROOT/scripts/common.sh"
 
 # Tear down Terraform-managed resources and remove generated tfvars
-cd "$ROOT/terraform" || exit; terraform destroy -input=false -auto-approve
-rm -f "$ROOT/terraform/terraform.tfvars"
+cd "$ROOT/terraform" || exit
+terraform destroy -input=false -auto-approve && rm -f "$ROOT/terraform/terraform.tfvars"


### PR DESCRIPTION
A corner case that happened to me.
During first `make teardown` something went wrong (`Error reading Service Account`) - `terraform destroy -input=false -auto-approve` failed and `rm -f "$ROOT/terraform/terraform.tfvars"` was executed.
To solve my problem I needed to regenerate tfvars with `./scripts/generate-tfvars.sh` and repeat `make teardown`. Second time it worked fine.

To avoid situation like this, it's better to remove tfvars file only when `terraform destroy` finished successfully.

Details from shell:
```
student_03_5796d34ed5d6@cloudshell:~/gke-security-scenarios-demo (qwiklabs-gcp-04-2de5924b802f)$ make teardown
Your active configuration is: [cloudshell-13857]
Your active configuration is: [cloudshell-13857]
module.bastion.data.null_data_source.grant_admin: Reading...
module.bastion.data.null_data_source.grant_admin: Read complete after 0s [id=static]
module.bastion.data.template_file.startup_script: Reading...
module.bastion.data.template_file.startup_script: Read complete after 0s [id=bec5a915dac52eb711903128a8d06db83c3e1178081cfc5421457b4b27dfa9ee]
google_service_account.admin: Refreshing state... [id=projects/qwiklabs-gcp-04-2de5924b802f/serviceAccounts/gke-tutorial-admin-ss@qwiklabs-gcp-04-2de5924b802f.iam.gserviceaccount.com]
data.google_container_engine_versions.on-prem: Reading...
module.network.google_compute_network.gke-network: Refreshing state... [id=kube-net-ss]
module.firewall.google_compute_firewall.bastion-ssh: Refreshing state... [id=gke-demo-bastion-fw]
module.network.google_compute_subnetwork.cluster-subnet: Refreshing state... [id=us-central1/kube-net-ss-subnet]
data.google_container_engine_versions.on-prem: Read complete after 1s [id=2022-10-11 20:49:26.847744329 +0000 UTC]
╷
│ Warning: "zone": [DEPRECATED] Use location instead
│
│   with data.google_container_engine_versions.on-prem,
│   on main.tf line 21, in data "google_container_engine_versions" "on-prem":
│   21: data "google_container_engine_versions" "on-prem" {
│
╵
╷
│ Warning: "additional_zones": [DEPRECATED] Use node_locations instead
│
│   with google_container_cluster.primary,
│   on main.tf line 63, in resource "google_container_cluster" "primary":
│   63: resource "google_container_cluster" "primary" {
│
╵
╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│
│   on provider.tf line 21, in provider "google":
│   21:   version = "~> 2.11.0"
│
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of
│ Terraform. To silence this warning, move the provider version constraint into the required_providers block.
│
│ (and 3 more similar warnings elsewhere)
╵
╷
│ Error: Error reading Service Account "projects/qwiklabs-gcp-04-2de5924b802f/serviceAccounts/gke-tutorial-admin-ss@qwiklabs-gcp-04-2de5924b802f.iam.gserviceaccount.com": Get https://iam.googleapis.com/v1/projects/qwiklabs-gcp-04-2de5924b802f/serviceAccounts/gke-tutorial-admin-ss@qwiklabs-gcp-04-2de5924b802f.iam.gserviceaccount.com?alt=json&prettyPrint=false: dial tcp [2a00:1450:4013:c1a::5f]:443: connect: cannot assign requested address
│
│   with google_service_account.admin,
│   on iam.tf line 20, in resource "google_service_account" "admin":
│   20: resource "google_service_account" "admin" {
│
╵
student_03_5796d34ed5d6@cloudshell:~/gke-security-scenarios-demo (qwiklabs-gcp-04-2de5924b802f)$ make teardown
Your active configuration is: [cloudshell-13857]
Your active configuration is: [cloudshell-13857]
╷
│ Warning: Version constraints inside provider configuration blocks are deprecated
│
│   on provider.tf line 21, in provider "google":
│   21:   version = "~> 2.11.0"
│
│ Terraform 0.13 and earlier allowed provider version constraints inside the provider configuration block, but that is now deprecated and will be removed in a future version of
│ Terraform. To silence this warning, move the provider version constraint into the required_providers block.
│
│ (and 3 more similar warnings elsewhere)
╵
╷
│ Error: No value for required variable
│
│   on variables.tf line 27:
│   27: variable "zone" {
│
│ The root module input variable "zone" is not set, and has no default value. Use a -var or -var-file command line argument to provide a value for this variable.
╵
╷
│ Error: No value for required variable
│
│   on variables.tf line 32:
│   32: variable "region" {
│
│ The root module input variable "region" is not set, and has no default value. Use a -var or -var-file command line argument to provide a value for this variable.
╵
╷
│ Error: No value for required variable
│
│   on variables.tf line 37:
│   37: variable "project" {
│
│ The root module input variable "project" is not set, and has no default value. Use a -var or -var-file command line argument to provide a value for this variable.
```